### PR TITLE
Feature s4

### DIFF
--- a/R/to-html.r
+++ b/R/to-html.r
@@ -319,7 +319,7 @@ to_html.special <- function(x, ...) {
 
 .Slabel <- function(type, bootstrap_label){
 	tag <- str_c("__%%", type, "%%__")
-	list(ctag=str_c('#', tag), tag=tag, label=str_c("<span class=\"label label-",bootstrap_label,"\">S3</span>"))
+	list(ctag=str_c('#', tag), tag=tag, label=str_c("<span class=\"label label-",bootstrap_label,"\">",type,"</span>"))
 }
 Slabels <- list(
 	S3=.Slabel('S3', 'success')


### PR DESCRIPTION

These patches implement colored labels for S3 and S4 methods in usage sections.
The signature of each method is also displayed.
For an example of how the result looks like see for example: http://nmf.r-forge.r-project.org/basis-coef-methods.html

This page suggests a potential improvement: also flag the S3 and S4 generics as such using similar flags.
