### PR TITLE
customizing templates and bootstrap

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -108,8 +108,10 @@ readme <- function(pkg = ".") {
 
 copy_bootstrap <- function(pkg = ".") {
   pkg <- as.sd_package(pkg)
-
-  bootstrap <- file.path(inst_path(), "bootstrap")
+  user_bootstrap <- pkg$bootstrap_path
+  bootstrap <- ifelse(file.exists(user_bootstrap), 
+                      user_bootstrap,
+                      file.path(inst_path(), "bootstrap"))
   file.copy(dir(bootstrap, full.names = TRUE), pkg$site_path, recursive = TRUE)
 }
 

--- a/R/package.r
+++ b/R/package.r
@@ -11,7 +11,8 @@
 #' @export
 #' @keywords internal
 #' @importFrom devtools parse_deps as.package
-as.sd_package <- function(pkg = ".", site_path = NULL, examples = NULL) {
+as.sd_package <- function(pkg = ".", site_path = NULL, examples = NULL,
+                            templates_path = NULL, bootstrap_path = NULL) {
   if (is.sd_package(pkg)) return(pkg)
 
   pkg <- as.package(pkg)
@@ -24,6 +25,10 @@ as.sd_package <- function(pkg = ".", site_path = NULL, examples = NULL) {
   settings <- load_settings(pkg)
   pkg$site_path <- site_path %||% settings$site_path %||% "inst/web"
   pkg$examples <- examples %||% settings$examples %||% TRUE
+  pkg$templates_path <- templates_path %||% settings$templates_path %||% 
+                                              "inst/staticdocs/templates"
+  pkg$bootstrap_path <- bootstrap_path %||% settings$bootstrap_path %||% 
+                                              "inst/staticdocs/bootstrap"                                                        
 
   if (!is.null(pkg$url)) {
     pkg$urls <- str_trim(str_split(pkg$url, ",")[[1]])

--- a/R/package.r
+++ b/R/package.r
@@ -7,6 +7,14 @@
 #' @param examples include examples or not? The default, \code{NULL}, first
 #'   looks at the value of \code{examples} set in \file{DESCRIPTION}, and if
 #'   not found uses \code{TRUE}.
+#' @param templates_path a specific directory path to use when searching for
+#'   rendering templates, in addition to the default locations of
+#'   packagedir/inst/staticdocs, packagedir/staticdocs, and the staticdocs
+#'   package's included templates directory.
+#' @param bootstrap_path a specific directory path to use when searching for
+#'   bootstrap style files, in addition to the default locations of
+#'   packagedir/inst/staticdocs, packagedir/staticdocs, and the staticdocs
+#'   package's included bootstrap directory.
 #' @return A named list of useful metadata about a package
 #' @export
 #' @keywords internal


### PR DESCRIPTION
I have added supports of customized themes and bootstrap files, which enable me to use bootstrap 3 in my own package documentation: [http://rtalks.net/iterpc/](http://rtalks.net/iterpc/)

For those interested in bootstrap 3 theme, you can have a look of [here](https://github.com/randy3k/iterpc/tree/master/inst/staticdocs)

Screenshot:
![screen shot 2014-04-01 at 1 30 54 am](https://cloud.githubusercontent.com/assets/1690993/2576958/fd308f86-b977-11e3-8e7c-333458ffead0.png)
