### PR TITLE
Small documentation update, overwrite vignettes on copying and improve dependencies in index.html

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -1,11 +1,12 @@
 #' Build complete static documentation for a package.
 #'
-#' Currently, knitr builds documentation for:
-#'
+#' Currently, build_site builds documentation for:
 #' \itemize{
-#'   \item Rd files.  Files
-#'   \item Demos. Must be listed in \file{demos/00index}.
-#'   \item Vignettes.
+#'   \item The package DESCRIPTION
+#'   \item Help topics
+#'   \item Vignettes
+#'   \item Demos. Must be listed in \file{demos/00index}
+#'   \item README.md files
 #' }
 #'
 #' @param pkg path to source version of package.  See
@@ -132,7 +133,7 @@ build_vignettes <- function(pkg = ".") {
   message("Copying vignettes")
   dest <- file.path(pkg$site_path, "vignettes")
   if (!file.exists(dest)) dir.create(dest)
-  file.copy(vigns$outputs, dest)
+  file.copy(vigns$outputs, dest, overwrite = TRUE)
 
   # Extract titles
   titles <- vapply(vigns$docs, FUN.VALUE = character(1), function(x) {

--- a/R/package.r
+++ b/R/package.r
@@ -72,6 +72,7 @@ as.sd_package <- function(pkg = ".", site_path = NULL, examples = NULL,
     suggests = str_c(parse_deps(pkg$suggests)$name, collapse = ", "),
     extends = str_c(parse_deps(pkg$extends)$name, collapse = ", ")
   )
+  pkg$dependencies <- ifelse(pkg$dependencies == "", FALSE, pkg$dependencies)
 
   pkg$rd <- package_rd(pkg)
   pkg$rd_index <- topic_index(pkg$rd)

--- a/inst/templates/content-index.html
+++ b/inst/templates/content-index.html
@@ -46,10 +46,10 @@
     {{#dependencies}}
     <h2>Dependencies</h2>
     <ul>
-      <li><strong>Depends</strong>: {{depends}}</li>
-      <li><strong>Imports</strong>: {{imports}}</li>
-      <li><strong>Suggests</strong>: {{suggests}}</li>
-      <li><strong>Extends</strong>: {{extends}}</li>
+      {{#depends}}<li><strong>Depends</strong>: {{depends}}</li>{{/depends}}
+      {{#imports}}<li><strong>Imports</strong>: {{imports}}</li>{{/imports}}
+      {{#suggests}}<li><strong>Suggests</strong>: {{suggests}}</li>{{/suggests}}
+      {{#extends}}<li><strong>Extends</strong>: {{extends}}</li>{{/extends}}
     </ul>
     {{/dependencies}}
 


### PR DESCRIPTION
After merging #69, only a few changes are left as it addressed most of the issues I found.

You can have a look at results generated using the branch of this pull request under

http://kinfit.r-forge.r-project.org/gmkin_static/index.html
http://kinfit.r-forge.r-project.org/mkin_static/index.html
http://kinfit.r-forge.r-project.org/kinfit_static/index.html