### PR TITLE
Customization of themes/ bootstrap and Adding Mathjax support

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -108,8 +108,12 @@ readme <- function(pkg = ".") {
 
 copy_bootstrap <- function(pkg = ".") {
   pkg <- as.sd_package(pkg)
-
-  bootstrap <- file.path(inst_path(), "bootstrap")
+  user_bootstrap <- pkg$bootstrap_path
+  if (file.exists(user_bootstrap)) {
+    bootstrap <- user_bootstrap
+  } else {
+    bootstrap <- file.path(inst_path(), "bootstrap")
+  }
   file.copy(dir(bootstrap, full.names = TRUE), pkg$site_path, recursive = TRUE)
 }
 
@@ -167,4 +171,3 @@ build_demos <- function(pkg = ".") {
 
   list(demo = unname(apply(cbind(filename, title), 1, as.list)))
 }
-

--- a/R/package.r
+++ b/R/package.r
@@ -11,13 +11,16 @@
 #'   rendering templates, in addition to the default locations of
 #'   packagedir/inst/staticdocs, packagedir/staticdocs, and the staticdocs
 #'   package's included templates directory.
+#' @param bootstrap_path a specific directory path to use when searching for
+#'   bootstrap style files, in addition to the default locations of
+#'   packagedir/inst/staticdocs, packagedir/staticdocs, and the staticdocs
+#'   package's included bootstrap directory.
 #' @return A named list of useful metadata about a package
 #' @export
 #' @keywords internal
 #' @importFrom devtools parse_deps as.package
 as.sd_package <- function(pkg = ".", site_path = NULL, examples = NULL,
-  templates_path = NULL) {
-
+  templates_path = NULL, bootstrap_path = NULL) {
   if (is.sd_package(pkg)) return(pkg)
 
   pkg <- as.package(pkg)
@@ -30,8 +33,10 @@ as.sd_package <- function(pkg = ".", site_path = NULL, examples = NULL,
   settings <- load_settings(pkg)
   pkg$site_path <- site_path %||% settings$site_path %||% "inst/web"
   pkg$examples <- examples %||% settings$examples %||% TRUE
-  pkg$templates_path <- templates_path %||% settings$templates_path %||% NULL
-
+  pkg$templates_path <- templates_path %||% settings$templates_path %||%
+                                              "inst/staticdocs/templates"
+  pkg$bootstrap_path <- bootstrap_path %||% settings$bootstrap_path %||%
+                                              "inst/staticdocs/bootstrap"
   if (!is.null(pkg$url)) {
     pkg$urls <- str_trim(str_split(pkg$url, ",")[[1]])
     pkg$url <- NULL

--- a/R/package.r
+++ b/R/package.r
@@ -15,12 +15,13 @@
 #'   bootstrap style files, in addition to the default locations of
 #'   packagedir/inst/staticdocs, packagedir/staticdocs, and the staticdocs
 #'   package's included bootstrap directory.
+#' @param mathjax whether to use mathjax to render math symbols.
 #' @return A named list of useful metadata about a package
 #' @export
 #' @keywords internal
 #' @importFrom devtools parse_deps as.package
 as.sd_package <- function(pkg = ".", site_path = NULL, examples = NULL,
-  templates_path = NULL, bootstrap_path = NULL) {
+  templates_path = NULL, bootstrap_path = NULL, mathjax = TRUE) {
   if (is.sd_package(pkg)) return(pkg)
 
   pkg <- as.package(pkg)
@@ -37,6 +38,7 @@ as.sd_package <- function(pkg = ".", site_path = NULL, examples = NULL,
                                               "inst/staticdocs/templates"
   pkg$bootstrap_path <- bootstrap_path %||% settings$bootstrap_path %||%
                                               "inst/staticdocs/bootstrap"
+  pkg$mathjax <- mathjax %||% settings$mathjax %||% TRUE
   if (!is.null(pkg$url)) {
     pkg$urls <- str_trim(str_split(pkg$url, ",")[[1]])
     pkg$url <- NULL

--- a/R/to-html.r
+++ b/R/to-html.r
@@ -191,19 +191,24 @@ to_html.item <- function(x, ...) {
 # Equations ------------------------------------------------------------------
 
 #' @export
-to_html.eqn <- function(x, ...) {
+to_html.eqn <- function(x, pkg, ...) {
   stopifnot(length(x) <= 2)
   ascii_rep <- x[[length(x)]]
-
-  str_c("<code class = 'eq'>", to_html.TEXT(ascii_rep, ...), "</code>")
+  if (pkg$mathjax){
+    str_c("$", to_html.TEXT(ascii_rep, ...), "$")
+  }else{
+    str_c("<code class = 'eq'>", to_html.TEXT(ascii_rep, ...), "</code>")
+  }
 }
 
 #' @export
-to_html.deqn <- function(x, ...) {
+to_html.deqn <- function(x, pkg, ...) {
   stopifnot(length(x) <= 2)
-  ascii_rep <- x[[length(x)]]
-
-  str_c("<pre class = 'eq'>", to_html.TEXT(ascii_rep, ...), "</pre>")
+  if (pkg$mathjax){
+    str_c("$$", to_html.TEXT(x[[length(x)-1]], ...), "$$")
+  }else{
+    str_c("<pre class = 'eq'>", to_html.TEXT(x[[length(x)]], ...), "</pre>")
+  }
 }
 
 # Links ----------------------------------------------------------------------

--- a/inst/templates/head.html
+++ b/inst/templates/head.html
@@ -11,3 +11,15 @@
 <!--[if lt IE 9]>
   <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
 <![endif]-->
+
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    tex2jax: {
+      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+      processEscapes: true
+    }
+  });
+</script>
+<script type="text/javascript"
+  src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>


### PR DESCRIPTION
I have rebased my PR in #62  and #64. It allows customizing themes and bootstrap files, which enables me to use bootstrap 3 in my own package documentation: http://randy.city/iterpc/. It also allows me to show math in the documentations.

![fd308f86-b977-11e3-8e7c-333458ffead0](https://cloud.githubusercontent.com/assets/1690993/7644687/a664d176-fa5d-11e4-9610-a5aa3668d30f.png)
![e2a5ca92-ba02-11e3-8055-0dd80a16e6b7](https://cloud.githubusercontent.com/assets/1690993/7644689/a80b59c8-fa5d-11e4-977e-723f72cabf3b.png)
