### PR TITLE
tweaking parse_rd and to_html.method

### DIFF
--- a/R/rd.r
+++ b/R/rd.r
@@ -13,7 +13,8 @@ parse_rd <- function(topic, package) {
   rd_raw <- utils:::.getHelpFile(rd_path(topic, package))
   rd <- structure(set_classes(rd_raw), class = "Rd_content")
   attr(rd, "Rd_tag") <- "Rd file"
-  print(rd)
+  #print(rd)
+  return(rd)
 }
 
 package_rd <- function(package) {

--- a/R/to-html.r
+++ b/R/to-html.r
@@ -275,8 +275,10 @@ make_link <- function(loc, label, pkg = NULL) {
     str_c("<a href='http://www.inside-r.org/r-doc/", loc$package,
           "/", loc$topic, "'>", label, "</a>")
   } else {
-    str_c("<a href='http://www.inside-r.org/packages/cran/", loc$package,
-      "/docs/", loc$topic, "'>", label, "</a>")
+#    str_c("<a href='http://www.inside-r.org/packages/cran/", loc$package,
+#      "/docs/", loc$topic, "'>", label, "</a>")
+    str_c("<a href='http://rpackages.ianhowson.com/cran/",
+          loc$package, "/man/", loc$topic, ".html'>", label, "</a>")
   }
 }
 

--- a/R/to-html.r
+++ b/R/to-html.r
@@ -325,7 +325,8 @@ to_html.special <- function(x, ...) {
 
 #' @export
 to_html.method <- function(x, ...) {
-  str_c('"', to_html(x[[1]], ...), '"')
+  ##                            CLASS                      method.class
+  str_c("## method for class '", x[[2]], "'\n", to_html(x[[1]], ".", x[[2]], ...), '')
 }
 #' @export
 to_html.S3method <- to_html.method


### PR DESCRIPTION
Recently `parse_rd` stopped returning anything (was only printing), with this fix, it returns a Rd_doc object (as expected).

Include classes for S3 and S4 methods. 
example:
http://docs.flowr.space/en/latest/rd/topics/complete-help.html#id151