### PR TITLE
Fix broken Bootstrap redirect in template footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ devtools::install_github("hadley/staticdocs")
 # Features
 
 * Attractive defaults: staticdocs uses [bootstrap]
-  (http://twitter.github.com/bootstrap/) to provide an attractive website.
+  (https://getbootstrap.com/2.0.4/) to provide an attractive website.
 
 * Customisable: you can override the default templates to provide
   alternative rendering

--- a/inst/templates/footer.html
+++ b/inst/templates/footer.html
@@ -1,2 +1,2 @@
 <p class="pull-right"><a href="#">Back to top</a></p>
-<p>Built by <a href="https://github.com/hadley/staticdocs">staticdocs</a>. Styled with <a href="http://twitter.github.com/bootstrap">bootstrap</a>.</p>
+<p>Built by <a href="https://github.com/hadley/staticdocs">staticdocs</a>. Styled with <a href="https://getbootstrap.com/2.0.4/">bootstrap</a>.</p>


### PR DESCRIPTION
http://twitter.github.com/bootstrap/ works, http://twitter.github.com/bootstrap doesn't. I didn't update the URL to getbootstrap.com to reflect that an older version is used.