### PR TITLE
Do not ignore title markup in index

### DIFF
--- a/R/build-index.r
+++ b/R/build-index.r
@@ -48,7 +48,7 @@ build_section <- function(section, pkg) {
 
     if (is.null(item$title)) {
       rd <- pkg$rd[[row$file_in]]
-      item$title <- extract_title(rd)
+      item$title <- extract_title(rd, pkg)
     }
 
     item$icon <- icon_path(pkg, item$name)
@@ -64,10 +64,11 @@ build_section <- function(section, pkg) {
   )
 }
 
-extract_title <- function(x) {
+extract_title <- function(x, pkg) {
   alias <- Find(function(x) attr(x, "Rd_tag") == "\\title", x)
-  alias <- alias[sapply(alias, `!=`, "\n")] # Remove lines consisting of only "\n"
-  alias[[1]][[1]]
+  alias <- to_html(alias, pkg)
+  alias <- gsub("\\s*\n", " ", alias)
+  alias
 }
 
 compact <- function (x) Filter(function(x) !is.null(x) & length(x), x)


### PR DESCRIPTION
`extract_title` doesn't parse markup elements such as `code` and `link` and therefore fails to simplify the result using `sapply` if an `Rd_content` subclass other than `TEXT` is encountered. This results in cut-off titles in the index that do not contain the original markup as well as all the following text. This has been fixed with a call to `to_html` and a `gsub` based newline replacement.