### PR TITLE
Admit .R extension and disable components selectively

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ Imports:
 Suggests:
     knitr
 VignetteBuilder: knitr
-RoxygenNote: 5.0.0
+RoxygenNote: 5.0.1

--- a/R/build.r
+++ b/R/build.r
@@ -155,12 +155,12 @@ build_demos <- function(pkg = ".") {
   demos <- readLines(file.path(demo_dir, "00Index"))
 
   pieces <- str_split_fixed(demos, "\\s+", 2)
-  in_path <- str_c(pieces[, 1], ".r")
+  in_path <- str_c(pieces[, 1], ".[rR]")
   filename <- str_c("demo-", pieces[,1], ".html")
   title <- pieces[, 2]
 
   for(i in seq_along(title)) {
-    demo_code <- readLines(file.path(demo_dir, in_path[i]))
+    demo_code <- readLines(Sys.glob(file.path(demo_dir, in_path[i])))
     demo_expr <- evaluate(demo_code, new.env(parent = globalenv()),
       new_device = FALSE)
 

--- a/R/build.r
+++ b/R/build.r
@@ -14,6 +14,9 @@
 #'   names are resolved.
 #' @param ... Other additional arguments passed to \code{\link{as.sd_package}}
 #'   used to override package defaults.
+#' @param with_vignettes If \code{TRUE}, will build vignettes.
+#' @param with_demos If \code{TRUE}, will build demos.
+#' @param with_readme If \code{TRUE}, will build the README.
 #' @param launch If \code{TRUE}, will open freshly generated site in web
 #'   browser.
 #' @export

--- a/R/build.r
+++ b/R/build.r
@@ -20,7 +20,9 @@
 #' @import stringr
 #' @importFrom devtools load_all
 #' @aliases staticdocs-package build_package
-build_site <- function(pkg = ".", ..., launch = interactive()) {
+build_site <- function(pkg = ".", ..., with_vignettes = TRUE,
+                       with_demos = TRUE, with_readme = TRUE,
+                       launch = interactive()) {
   pkg <- as.sd_package(pkg, ...)
   load_all(pkg)
 
@@ -30,9 +32,9 @@ build_site <- function(pkg = ".", ..., launch = interactive()) {
   copy_bootstrap(pkg)
 
   pkg$topics <- build_topics(pkg)
-  pkg$vignettes <- build_vignettes(pkg)
-  pkg$demos <- build_demos(pkg)
-  pkg$readme <- readme(pkg)
+  if (with_vignettes) pkg$vignettes <- build_vignettes(pkg)
+  if (with_demos) pkg$demos <- build_demos(pkg)
+  if (with_readme) pkg$readme <- readme(pkg)
   build_index(pkg)
 
   if (launch) launch(pkg)

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -6,7 +6,8 @@
 \alias{staticdocs-package}
 \title{Build complete static documentation for a package.}
 \usage{
-build_site(pkg = ".", ..., launch = interactive())
+build_site(pkg = ".", ..., with_vignettes = TRUE, with_demos = TRUE,
+  with_readme = TRUE, launch = interactive())
 }
 \arguments{
 \item{pkg}{path to source version of package.  See

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -17,6 +17,12 @@ names are resolved.}
 \item{...}{Other additional arguments passed to \code{\link{as.sd_package}}
 used to override package defaults.}
 
+\item{with_vignettes}{If \code{TRUE}, will build vignettes.}
+
+\item{with_demos}{If \code{TRUE}, will build demos.}
+
+\item{with_readme}{If \code{TRUE}, will build the README.}
+
 \item{launch}{If \code{TRUE}, will open freshly generated site in web
 browser.}
 }


### PR DESCRIPTION
* `build_demos` now admits `.R` files as well as `.r`.
* `build_site` has individual flags for vignettes (`with_vignettes`), demos (`with_demos`) and readme (`with_readme`).