### PR TITLE
Remove directories after dir().

### DIFF
--- a/R/rd.r
+++ b/R/rd.r
@@ -20,6 +20,7 @@ package_rd <- function(package) {
   package <- as.sd_package(package)
 
   rd <- dir(file.path(package$path, "man"), full.names = TRUE)
+  rd <- rd[!(rd %in% list.dirs(file.path(package$path, "man"), recursive=FALSE))]
   names(rd) <- basename(rd)
   lapply(rd, cached_parse_Rd)
 }


### PR DESCRIPTION
I am trying out ``build_site()`` on a package which has a ``man/figures`` directory. I get the error:

```Error: The specified pathname is not a file: [...]/man/figures```

``traceback()`` shows that this happens due to ``digest()``. In ``rd.r``, I see ``package_rd()``, which uses

```rd <- dir(file.path(package$path, "man"), full.names = TRUE)```

to get all files in the directory, but this also includes directories themselves (despite ``include.dirs=FALSE``, directories still get included when using a non-recursive listing, which is the default).

So the directories need to be filtered out.