### PR TITLE
	fix bug related to \eqn and \deqn

### DIFF
--- a/R/rd.r
+++ b/R/rd.r
@@ -16,14 +16,14 @@ parse_rd <- function(topic, package) {
   print(rd)
 }
 
-rd2html <- function(x, fragment = FALSE) {
+rd2html <- function(x, fragment = FALSE, ...) {
   con <- textConnection(x)
   on.exit(close(con), add = TRUE)
 
   rd_raw <- tools::parse_Rd(con, fragment = fragment)
   rd <- structure(set_classes(rd_raw), class = "Rd_content")
 
-  str_trim(str_split(str_trim(to_html(rd)), "\n")[[1]])
+  str_trim(str_split(str_trim(to_html(rd, ...)), "\n")[[1]])
 }
 
 get_help_file <- function(path) {

--- a/R/to-html.r
+++ b/R/to-html.r
@@ -232,10 +232,11 @@ to_html.item <- function(x, ...) {
 #' @export
 to_html.eqn <- function(x, pkg, ...) {
   stopifnot(length(x) <= 2)
-  ascii_rep <- x[[length(x)]]
   if (pkg$mathjax){
-    str_c("$", to_html.TEXT(ascii_rep, ...), "$")
+    latex_rep <- x[[1]]
+    str_c("$", to_html.TEXT(latex_rep, ...), "$")
   }else{
+    ascii_rep <- x[[length(x)]]
     str_c("<code class = 'eq'>", to_html.TEXT(ascii_rep, ...), "</code>")
   }
 }
@@ -244,9 +245,11 @@ to_html.eqn <- function(x, pkg, ...) {
 to_html.deqn <- function(x, pkg, ...) {
   stopifnot(length(x) <= 2)
   if (pkg$mathjax){
-    str_c("$$", to_html.TEXT(x[[length(x)-1]], ...), "$$")
+    latex_rep <- x[[1]]
+    str_c("$$", to_html.TEXT(latex_rep, ...), "$$")
   }else{
-    str_c("<pre class = 'eq'>", to_html.TEXT(x[[length(x)]], ...), "</pre>")
+    ascii_rep <- x[[length(x)]]
+    str_c("<pre class = 'eq'>", to_html.TEXT(ascii_rep, ...), "</pre>")
   }
 }
 

--- a/tests/testthat/test-to_html.R
+++ b/tests/testthat/test-to_html.R
@@ -18,3 +18,26 @@ test_that("S3 methods gets comment", {
   expect_equal(out[1], "# S3 method for class")
   expect_equal(out[2], "fun(x, y)")
 })
+
+
+test_that("eqn", {
+  out <- rd2html(" \\eqn{\\alpha}{alpha}", TRUE, pkg=list(mathjax = TRUE))
+  expect_equal(out, "$\\alpha$")
+  out <- rd2html(" \\eqn{\\alpha}{alpha}", TRUE, pkg=list(mathjax = FALSE))
+  expect_equal(out, "<code class = 'eq'>alpha</code>")
+  out <- rd2html(" \\eqn{x}", TRUE, pkg=list(mathjax = TRUE))
+  expect_equal(out, "$x$")
+  out <- rd2html(" \\eqn{x}", TRUE, pkg=list(mathjax = FALSE))
+  expect_equal(out, "<code class = 'eq'>x</code>")
+})
+
+test_that("deqn", {
+  out <- rd2html(" \\deqn{\\alpha}{alpha}", TRUE, pkg=list(mathjax = TRUE))
+  expect_equal(out, "$$\\alpha$$")
+  out <- rd2html(" \\deqn{\\alpha}{alpha}", TRUE, pkg=list(mathjax = FALSE))
+  expect_equal(out, "<pre class = 'eq'>alpha</pre>")
+  out <- rd2html(" \\deqn{x}", TRUE, pkg=list(mathjax = TRUE))
+  expect_equal(out, "$$x$$")
+  out <- rd2html(" \\deqn{x}", TRUE, pkg=list(mathjax = FALSE))
+  expect_equal(out, "<pre class = 'eq'>x</pre>")
+})


### PR DESCRIPTION
\eqn and \deqn have two formats: \eqn{latex}{ascii} and \eqn{latexascii}
they are correctly handled now

fix #101