### PR TITLE
Use as.person to allow strings in Authors@R

### DIFF
--- a/R/package.r
+++ b/R/package.r
@@ -55,6 +55,7 @@ as.sd_package <- function(pkg = ".", site_path = NULL, examples = NULL,
     }
 
     pkg$authors <- eval(parse(text = pkg$`authors@r`))
+    pkg$authors <- as.person(pkg$authors)
     pkg$authors <- sapply(pkg$authors, str_person)
   }
 


### PR DESCRIPTION
Works for me.

NEWS entry:

```
* Support for strings (in addition to `person()` calls) in `Authors@R` (#106, @krlmlr).
```