### PR TITLE
Create staticdocs directory if it doesn't exist

### DIFF
--- a/R/util.r
+++ b/R/util.r
@@ -30,10 +30,10 @@ pkg_sd_path <- function(package, site_path) {
     pathsrc
   else if (dir.exists(pathinst))
     pathinst
-  else
-    stop("Folder inst/staticdocs doesn't exist. Specify site_path or create a package folder inst/staticdocs.")
-
-
+  else {
+    dir.create(pathsrc)
+    pathsrc
+  }
 }
 
 file.path.ci <- function(...) {


### PR DESCRIPTION
Works for me, helps automation.

NEWS entry:

 ```
* If no directory `staticdocs` or `inst/staticdocs` exists, and neither `sd_path` and `site_path` are set,
  the the directory `inst/staticdocs` is created, and documentation is created there (#108, @krlmlr).
```