### PR TITLE
Forward external documentation to rdocumentation.org

### DIFF
--- a/R/to-html.r
+++ b/R/to-html.r
@@ -271,12 +271,9 @@ to_html.link <- function(x, pkg, ...) {
 make_link <- function(loc, label, pkg = NULL) {
   if (is.null(loc$package)) {
     str_c("<a href='", loc$file, "'>", label, "</a>")
-  } else if (loc$package %in% builtin_packages) {
-    str_c("<a href='http://www.inside-r.org/r-doc/", loc$package,
-          "/", loc$topic, "'>", label, "</a>")
   } else {
-    str_c("<a href='http://www.inside-r.org/packages/cran/", loc$package,
-      "/docs/", loc$topic, "'>", label, "</a>")
+    str_c("<a href='http://www.rdocumentation.org/packages/", loc$package,
+      "/topics/", loc$topic, "'>", label, "</a>")
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ Compared to `Rd2html`, staticdocs:
 * Runs examples, so users see both input and output.
 
 * Assumes only one package is being rendered - links to documentation in
-  other packages are forwarded to [inside-R](http://www.inside-r.org/).
+  other packages are forwarded to [Rdocumentation](http://www.rdocumentation.org/).


### PR DESCRIPTION
instead of inside-r.org.

Fixes #34.

NEWS entry:

```
* External documentation is now forwarded to http://www.rdocumentation.org (#113, @krlmlr).
```