### PR TITLE
Fix local links with explicit package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - ./travis-tool.sh r_binary_install knitr
   - ./travis-tool.sh r_binary_install rgl
   - ./travis-tool.sh r_binary_install XML
+  - ./travis-tool.sh r_binary_install roxygen2
   - ./travis-tool.sh install_deps
 
 script:

--- a/R/to-html.r
+++ b/R/to-html.r
@@ -259,6 +259,13 @@ to_html.link <- function(x, pkg, ...) {
     }
   }
 
+  # Special case: need to remove the package qualification if help is explicitly
+  # requested from the package for which documentation is rendered.
+  # Otherwise find_topic() -> rd_path() will open the development version of the
+  # help page, because the package is loaded with devtools::load_all().
+  if (t_package == pkg$package)
+    t_package <- NULL
+
   loc <- find_topic(topic, t_package, pkg$rd_index)
   if (is.null(loc)) {
     message("Can't find help topic ", topic)

--- a/R/to-html.r
+++ b/R/to-html.r
@@ -263,7 +263,7 @@ to_html.link <- function(x, pkg, ...) {
   # requested from the package for which documentation is rendered.
   # Otherwise find_topic() -> rd_path() will open the development version of the
   # help page, because the package is loaded with devtools::load_all().
-  if (t_package == pkg$package)
+  if (isTRUE(all.equal(t_package, pkg$package)))
     t_package <- NULL
 
   loc <- find_topic(topic, t_package, pkg$rd_index)

--- a/R/to-html.r
+++ b/R/to-html.r
@@ -263,8 +263,9 @@ to_html.link <- function(x, pkg, ...) {
   # requested from the package for which documentation is rendered.
   # Otherwise find_topic() -> rd_path() will open the development version of the
   # help page, because the package is loaded with devtools::load_all().
-  if (isTRUE(all.equal(t_package, pkg$package)))
+  if (!is.null(t_package) && t_package == pkg$package) {
     t_package <- NULL
+  }
 
   loc <- find_topic(topic, t_package, pkg$rd_index)
   if (is.null(loc)) {


### PR DESCRIPTION
Links of the type `\link[pkg]{topic}`, where `pkg` is the package for which documentation is generated, work now.

Needed for having DBI specs in DBI.

Closes #114 (=includes it).

NEWS entry:

```
* Fix rendering of links of the form `\link[pkg]{topic}` where `pkg` is the current package (#115, @krlmlr).
```