### PR TITLE
Remove generated .html under /vignettes

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -139,6 +139,7 @@ build_vignettes <- function(pkg = ".") {
   dest <- file.path(pkg$site_path, "vignettes")
   if (!file.exists(dest)) dir.create(dest)
   file.copy(vigns$outputs, dest, overwrite = TRUE)
+  file.remove(vigns$outputs)
 
   # Extract titles
   titles <- vapply(vigns$docs, FUN.VALUE = character(1), function(x) {


### PR DESCRIPTION
Vignette outputs are removed in origin after being copied.