### PR TITLE
create inst/ if missing and stop if no topics

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -96,7 +96,7 @@ build_package <- function(...) {
 # Generate all topic pages for a package.
 build_topics <- function(pkg = ".") {
   pkg <- as.sd_package(pkg)
-
+  if (length(pkg$index) < 1L) stop("no topics found to build")
   # for each file, find name of one topic
   index <- pkg$rd_index
   paths <- file.path(pkg$site_path, index$file_out)

--- a/R/util.r
+++ b/R/util.r
@@ -25,7 +25,7 @@ pkg_sd_path <- function(package) {
   } else if (dir.exists(pathinst)) {
     pathinst
   } else {
-    dir.create(pathsrc)
+    dir.create(pathsrc, recursive = TRUE)
     pathsrc
   }
 }


### PR DESCRIPTION
1. I found that build_site() will error if inst/ does not exist. adding recursive = TRUE fixes that. 

2. Added  a catch to stop() if no topics found (i.e. if build_site is called on an empty stub package with no functions). 